### PR TITLE
Use Python 2/3 compatible dictionary iteration methods

### DIFF
--- a/templates/pool.conf.j2
+++ b/templates/pool.conf.j2
@@ -3,11 +3,11 @@
 
 [{{ item.name }}]
 ; Defaults
-{% for directive, value in php_fpm_pool_defaults.iteritems() %}
+{% for directive, value in php_fpm_pool_defaults.items() | list %}
   {{ directive }} = {{ value }}
 {% endfor %}
 
 ; Pool custom directives
-{% for directive, value in item.iteritems() if directive != "name" %}
+{% for directive, value in item.items() | list if directive != "name" %}
   {{ directive }} = {{ value }}
 {% endfor %}


### PR DESCRIPTION
Hello.

I was getting errors with the dictionary iteration methods when using this role under Python 3, so I changed them as described here: [https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems](https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems). It works with both Python 2 and 3 now.